### PR TITLE
feat: Add `clear` command to delete all microvms

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ hammertime list
 
 # delete
 hammertime delete -i <UID>
+
+# delete all mvms everywhere
+hammertime clear
 ```
 
 The name and namespace are configurable, as are the GRPC address and port.

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	github.com/urfave/cli/v2 v2.3.0
-	github.com/weaveworks/flintlock/api v0.0.0-20220126104712-74e49997e1bf
-	github.com/weaveworks/flintlock/client v0.0.0-20220110105514-c0ec7b5054ee
+	github.com/weaveworks/flintlock/api v0.0.0-20220207161056-11b7da1e4969
+	github.com/weaveworks/flintlock/client v0.0.0-20220207161056-11b7da1e4969
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -178,10 +178,10 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
-github.com/weaveworks/flintlock/api v0.0.0-20220126104712-74e49997e1bf h1:U4uOomP3oci4tP9f8W2uxGlC2tSQKbLQZKNWXg+YcXQ=
-github.com/weaveworks/flintlock/api v0.0.0-20220126104712-74e49997e1bf/go.mod h1:RFgQ7RSa7zGNxxR+dS6NRDCQ/IAN23WCfXg4+L6fclI=
-github.com/weaveworks/flintlock/client v0.0.0-20220110105514-c0ec7b5054ee h1:qBmT4sop1gKsDe6oMfOopaoXsTnpnkh0C0wV52RVt6c=
-github.com/weaveworks/flintlock/client v0.0.0-20220110105514-c0ec7b5054ee/go.mod h1:1jiepUOR2kxAdoxXXyNQ0LnOeT2gOUSnWGuXh9akjDw=
+github.com/weaveworks/flintlock/api v0.0.0-20220207161056-11b7da1e4969 h1:KaPGquph5amu+FyTnPYHgIIMPmxh955/zuddcOcyuiY=
+github.com/weaveworks/flintlock/api v0.0.0-20220207161056-11b7da1e4969/go.mod h1:RFgQ7RSa7zGNxxR+dS6NRDCQ/IAN23WCfXg4+L6fclI=
+github.com/weaveworks/flintlock/client v0.0.0-20220207161056-11b7da1e4969 h1:j5jPIUaDGpSQw2z1Qh/EcL8Jmw6WvJqac2ln3MvFKSk=
+github.com/weaveworks/flintlock/client v0.0.0-20220207161056-11b7da1e4969/go.mod h1:1jiepUOR2kxAdoxXXyNQ0LnOeT2gOUSnWGuXh9akjDw=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/test/fakeserver/main.go
+++ b/test/fakeserver/main.go
@@ -96,7 +96,7 @@ func (s *fakeServer) ListMicroVMs(ctx context.Context, req *mvmv1.ListMicroVMsRe
 	microvms := []*types.MicroVM{}
 
 	for _, spec := range s.savedSpecs {
-		if req.Namespace == "" || req.Namespace == spec.Namespace {
+		if shouldReturn(spec, req.Name, req.Namespace) {
 			m := &types.MicroVM{
 				Version: 0,
 				Spec:    spec,
@@ -111,6 +111,17 @@ func (s *fakeServer) ListMicroVMs(ctx context.Context, req *mvmv1.ListMicroVMsRe
 	return &mvmv1.ListMicroVMsResponse{
 		Microvm: microvms,
 	}, nil
+}
+
+func shouldReturn(spec *types.MicroVMSpec, name *string, namespace string) bool {
+	if spec.Namespace == namespace && spec.Id == *name {
+		return true
+	}
+	if spec.Namespace == namespace && *name == "" {
+		return true
+	}
+
+	return namespace == ""
 }
 
 func (s *fakeServer) ListMicroVMsStream(req *mvmv1.ListMicroVMsRequest, streamServer mvmv1.MicroVM_ListMicroVMsStreamServer) error {


### PR DESCRIPTION
Users can:
- Delete all mvms in all namespaces
- Delete all mvms in a namespace/name group
- Delete all mvms in a namespace

Also bumps flintlock to latest.

I could have done this as a `delete --all` subcommand, but then I
thought the UX would be weird for filtering for namespace/names etc.
I keep going back and forward on it, so it may end up there. But for now
it is its own command.
