### PR TITLE
Add ability to get mvm with name and/or namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,14 @@ as JSON so you can pipe to `jq` or whatever as you like.
 # create 'mvm0' in 'ns0' (take note of the UID after creation)
 hammertime create
 
-# get
-hammertime get -i <UUID>
+# get 'mvm0' in 'ns0' 
+hammertime get
 
 # get just the state of 'mvm0' in 'ns0' *see below
-hammertime get -i <UUID> -s
+hammertime get -s
+
+# get
+hammertime get -i <UUID>
 
 # get all mvms across all namespaces
 hammertime list


### PR DESCRIPTION
Users can: 
- get mvm in default name/namespace (no args)
- get mvm in a namespace (using `--ns` or `--namespace`)
- get mvm by name (using `--n` or `--name`)
- get mvm in a name/namespace group (using both `--n` and `--ns`)

In all those cases, if more than one mvm is present , it will return the `uuids` .

Solves #14 